### PR TITLE
Update 3-account-linking-md

### DIFF
--- a/instructions/3-account-linking.md
+++ b/instructions/3-account-linking.md
@@ -43,8 +43,9 @@ With the details set in your Trailhead Playground Org, we can set up account lin
 
 ```
 $ ask api create-account-linking -s <Skill ID>
+? Allow users to enable skill without account linking:  Yes
 ? Authorization URL:  https://login.salesforce.com/services/oauth2/authorize
-? Client ID:  <Your Client ID>
+? Client ID:  <Your Client ID / Consumer Key>
 ? Scopes(separate by comma):  api,refresh_token
 ? Domains(separate by comma):  
 ? Authorization Grant Type:  AUTH_CODE


### PR DESCRIPTION
*Issue #, if available: n/a*

*Description of changes:*
There is an additional inital prompt in the latest version of the ASK CLI that now appears which is not noted here: `? Allow users to enable skill without account linking:  Yes` - if this is set to No, simulation fails. Also, clarified that the Client ID is the Salesforce Consumer Key in this example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
